### PR TITLE
Add .git-blame-ignore-revs file containing format commits

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# scalafmt
+7ce76e2584fc2e23f35a121e55a55aaf33852749


### PR DESCRIPTION
Similar to pekko core, adds a .git-blame-ignore-revs which contains the hashes for the previous scalafmt commits.