### PR TITLE
Add github workflow to check scala code is formatted

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -33,8 +33,8 @@ jobs:
       - name: Cache Coursier cache
         uses: coursier/cache-action@v5
 
-      - name: Code style check, compilation and binary-compatibility check
-        run: sbt "scalafmtCheckAll;headerCheckAll;+IntegrationTest/compile;mimaReportBinaryIssues"
+      - name: Compilation and binary-compatibility check
+        run: sbt "headerCheckAll;+IntegrationTest/compile;mimaReportBinaryIssues"
 
   check-docs:
     name: Check Docs

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,0 +1,24 @@
+name: Scalafmt
+
+permissions: read-all
+
+on:
+  pull_request:
+    branches: ['**']
+
+jobs:
+  build:
+    name: Code is formatted
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout current branch (full)
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Check project is formatted
+        uses: jrouly/scalafmt-native-action@v2
+        with:
+          version: '3.6.1'
+          arguments: '--list --mode diff-ref=origin/main'


### PR DESCRIPTION
Similar to pekko core, replaces the sbt scalafmt check with a github actions one. Also removes the `scalafmtCheckAll` from the current github actions.