### PR TITLE
upgrade cache-action to v6.4.0

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -31,7 +31,7 @@ jobs:
           java-version: adopt@1.11.0-9
 
       - name: Cache Coursier cache
-        uses: coursier/cache-action@v5
+        uses: coursier/cache-action@v6.4.0
 
       - name: Compilation and binary-compatibility check
         run: sbt "headerCheckAll;+IntegrationTest/compile;mimaReportBinaryIssues"
@@ -57,7 +57,7 @@ jobs:
           java-version: adopt@1.11.0-9
 
       - name: Cache Coursier cache
-        uses: coursier/cache-action@v5
+        uses: coursier/cache-action@v6.4.0
 
       - name: Create all API docs for artifacts/website and all reference docs
         run: sbt "unidoc; docs/paradox"

--- a/.github/workflows/integration-tests-kube-api.yml
+++ b/.github/workflows/integration-tests-kube-api.yml
@@ -34,7 +34,7 @@ jobs:
           java-version: adopt@1.11.0-9
 
       - name: Cache Coursier cache
-        uses: coursier/cache-action@v5
+        uses: coursier/cache-action@v6.4.0
 
       - name: Setup Minikube
         uses: manusa/actions-setup-minikube@v2.4.2

--- a/.github/workflows/integration-tests-kube-dns.yml
+++ b/.github/workflows/integration-tests-kube-dns.yml
@@ -34,7 +34,7 @@ jobs:
           java-version: adopt@1.11.0-9
 
       - name: Cache Coursier cache
-        uses: coursier/cache-action@v5
+        uses: coursier/cache-action@v6.4.0
 
       - name: Setup Minikube
         uses: manusa/actions-setup-minikube@v2.4.2

--- a/.github/workflows/integration-tests-lease.yml
+++ b/.github/workflows/integration-tests-lease.yml
@@ -34,7 +34,7 @@ jobs:
           java-version: adopt@1.11.0-9
 
       - name: Cache Coursier cache
-        uses: coursier/cache-action@v5
+        uses: coursier/cache-action@v6.4.0
 
       - name: Setup Minikube
         uses: manusa/actions-setup-minikube@v2.4.2

--- a/.github/workflows/integration-tests-maven.yml
+++ b/.github/workflows/integration-tests-maven.yml
@@ -35,7 +35,7 @@ jobs:
           java-version: adopt@1.11.0-9
 
       - name: Cache Coursier cache
-        uses: coursier/cache-action@v5
+        uses: coursier/cache-action@v6.4.0
 
       - name: Setup Minikube
         uses: manusa/actions-setup-minikube@v2.4.2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
         uses: olafurpg/setup-scala@v10
 
       - name: Cache Coursier cache
-        uses: coursier/cache-action@v5
+        uses: coursier/cache-action@v6.4.0
 
       - name: Publish artifacts for all Scala versions
         env:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -40,7 +40,7 @@ jobs:
           java-version: ${{ matrix.java-version }}
 
       - name: Cache Coursier cache
-        uses: coursier/cache-action@v5
+        uses: coursier/cache-action@v6.4.0
 
       # hack to solve "Cannot assign requested address" issue - https://github.community/t/github-action-and-oserror-errno-99-cannot-assign-requested-address/173973/1
       - name: Add the current IP address, long hostname and short hostname record to /etc/hosts file

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.7.1
+sbt.version=1.8.0


### PR DESCRIPTION
fix for https://github.com/apache/incubator-pekko-management/actions/runs/3458091679

also relates to https://github.com/apache/incubator-pekko/pull/42