### PR TITLE
Add tailrec to recursive function calls

### DIFF
--- a/management-cluster-bootstrap/src/test/scala/org/apache/pekko/discovery/MockDiscovery.scala
+++ b/management-cluster-bootstrap/src/test/scala/org/apache/pekko/discovery/MockDiscovery.scala
@@ -20,6 +20,7 @@ import pekko.annotation.InternalApi
 import pekko.discovery.ServiceDiscovery.Resolved
 import pekko.event.Logging
 
+import scala.annotation.tailrec
 import scala.concurrent.Future
 import scala.concurrent.duration.FiniteDuration
 
@@ -30,12 +31,14 @@ object MockDiscovery {
   def set(name: Lookup, to: () => Future[Resolved]): Unit =
     set(name, _ => to())
 
+  @tailrec
   def set(name: Lookup, to: ActorSystem => Future[Resolved]): Unit = {
     val d = data.get()
     if (data.compareAndSet(d, d.updated(name, to))) ()
     else set(name, to) // retry
   }
 
+  @tailrec
   def remove(name: Lookup): Unit = {
     val d = data.get()
     if (data.compareAndSet(d, d - name)) ()

--- a/management/src/main/scala/org/apache/pekko/management/scaladsl/PekkoManagement.scala
+++ b/management/src/main/scala/org/apache/pekko/management/scaladsl/PekkoManagement.scala
@@ -36,6 +36,7 @@ import pekko.util.ManifestInfo
 
 import java.util.Optional
 import java.util.concurrent.atomic.AtomicReference
+import scala.annotation.tailrec
 import scala.collection.immutable
 import scala.compat.java8.FutureConverters._
 import scala.compat.java8.OptionConverters._
@@ -216,6 +217,7 @@ final class PekkoManagement(implicit private[pekko] val system: ExtendedActorSys
         "Double check your `pekko.management.http.routes` config.")
   }
 
+  @tailrec
   def stop(): Future[Done] = {
     val binding = bindingFuture.get()
 


### PR DESCRIPTION
A small nice to have, I noticed that certain function calls in this project are tail call recursive but don't have the `@tailrec` annotation.

Note that this shouldn't have any impact on the generated bytecode in the JVM classes. The scala compiler will automatically convert local recursion into loops if it can do so, all the `@tailrec` annotation does is it makes the compiler enforce that it can convert it to a while loop (and if it doesn't then this generates a compile error). This means that the change should be safe for the 1.0.0 release.