### PR TITLE
set github-token when using minikube action to avoid rate limit issues

### DIFF
--- a/.github/workflows/integration-tests-kube-api.yml
+++ b/.github/workflows/integration-tests-kube-api.yml
@@ -38,11 +38,12 @@ jobs:
         uses: coursier/cache-action@v6.4.0
 
       - name: Setup Minikube
-        uses: manusa/actions-setup-minikube@v2.4.2
+        uses: manusa/actions-setup-minikube@v2.7.2
         with:
           minikube version: 'v1.21.0'
           kubernetes version: 'v1.21.0'
           driver: docker
+          github token: ${{ secrets.GITHUB_TOKEN }}
           start args: '--addons=ingress'
 
       - name: Run Integration Tests

--- a/.github/workflows/integration-tests-kube-dns.yml
+++ b/.github/workflows/integration-tests-kube-dns.yml
@@ -38,11 +38,12 @@ jobs:
         uses: coursier/cache-action@v6.4.0
 
       - name: Setup Minikube
-        uses: manusa/actions-setup-minikube@v2.4.2
+        uses: manusa/actions-setup-minikube@v2.7.2
         with:
           minikube version: 'v1.21.0'
           kubernetes version: 'v1.21.0'
           driver: docker
+          github token: ${{ secrets.GITHUB_TOKEN }}
           start args: '--addons=ingress'
 
       - name: Run Integration Tests

--- a/.github/workflows/integration-tests-lease.yml
+++ b/.github/workflows/integration-tests-lease.yml
@@ -38,11 +38,12 @@ jobs:
         uses: coursier/cache-action@v6.4.0
 
       - name: Setup Minikube
-        uses: manusa/actions-setup-minikube@v2.4.2
+        uses: manusa/actions-setup-minikube@v2.7.2
         with:
           minikube version: 'v1.21.0'
           kubernetes version: 'v1.21.0'
           driver: docker
+          github token: ${{ secrets.GITHUB_TOKEN }}
           start args: '--addons=ingress'
 
       - name: Run Integration Tests

--- a/.github/workflows/integration-tests-maven.yml
+++ b/.github/workflows/integration-tests-maven.yml
@@ -39,11 +39,12 @@ jobs:
         uses: coursier/cache-action@v6.4.0
 
       - name: Setup Minikube
-        uses: manusa/actions-setup-minikube@v2.4.2
+        uses: manusa/actions-setup-minikube@v2.7.2
         with:
           minikube version: 'v1.21.0'
           kubernetes version: 'v1.21.0'
           driver: docker
+          github token: ${{ secrets.GITHUB_TOKEN }}
           start args: '--addons=ingress'
 
       - name: Start docker


### PR DESCRIPTION
* one issue is that we are hitting rate limits - https://docs.github.com/en/rest/overview/resources-in-the-rest-api?apiVersion=2022-11-28#rate-limiting%5C
* eg https://github.com/apache/incubator-pekko-management/actions/runs/4303045205/jobs/7502292086