### PR TITLE
Make sbt project ids/names consistent with Pekko projects

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -35,6 +35,7 @@ lazy val root = project
     leaseKubernetesIntTest,
     docs)
   .settings(
+    name := "pekko-management-root",
     GlobalScope / parallelExecution := false,
     publish / skip := true)
 
@@ -252,7 +253,7 @@ lazy val docs = project
   .enablePlugins(AkkaParadoxPlugin, ParadoxSitePlugin, PreprocessPlugin, PublishRsyncPlugin)
   .disablePlugins(MimaPlugin)
   .settings(
-    name := "Apache Pekko Management",
+    name := "pekko-management-docs",
     publish / skip := true,
     makeSite := makeSite.dependsOn(LocalRootProject / ScalaUnidoc / doc).value,
     Preprocess / siteSubdirName := s"api/pekko-management/${if (isSnapshot.value) "snapshot" else version.value}",


### PR DESCRIPTION
Self explanatory, the `name` change is a nice QOL improvement because since its currently `root` right now, IDE's like Intellij import the projects name from `root / name` which means that currently it appears as `root`, i.e. 

<img width="315" alt="image" src="https://user-images.githubusercontent.com/2337269/222684066-d89bafee-12a5-4b10-9cb1-fc3de6d8ace1.png">