### PR TITLE
Format java sources

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -290,12 +290,8 @@ def pekkoIntTestModule(moduleName: String): Project =
   Project(id = s"integration-test-$moduleName", base = file(s"integration-test/$moduleName"))
 
 TaskKey[Unit]("verifyCodeFmt") := {
-  scalafmtCheckAll.all(ScopeFilter(inAnyProject)).result.value.toEither.left.foreach { _ =>
+  javafmtCheckAll.all(ScopeFilter(inAnyProject)).result.value.toEither.left.foreach { _ =>
     throw new MessageOnlyException(
-      "Unformatted Scala code found. Please run 'scalafmtAll' and commit the reformatted code")
-  }
-  (Compile / scalafmtSbtCheck).result.value.toEither.left.foreach { _ =>
-    throw new MessageOnlyException(
-      "Unformatted sbt code found. Please run 'scalafmtSbt' and commit the reformatted code")
+      "Unformatted Java code found. Please run 'javafmtAll' and commit the reformatted code")
   }
 }

--- a/discovery-aws-api/src/test/java/org/apache/pekko/discovery/awsapi/ec2/MyConfiguration.java
+++ b/discovery-aws-api/src/test/java/org/apache/pekko/discovery/awsapi/ec2/MyConfiguration.java
@@ -13,7 +13,7 @@
 
 package org.apache.pekko.discovery.awsapi.ec2;
 
-//#custom-client-config
+// #custom-client-config
 // package com.example;
 
 import com.amazonaws.ClientConfiguration;
@@ -27,9 +27,9 @@ class MyConfiguration extends ClientConfiguration {
 
     setRetryPolicy(PredefinedRetryPolicies.NO_RETRY_POLICY);
     // If you're using this module for bootstrapping your Akka cluster,
-    // Cluster Bootstrap already has its own retry/back-off mechanism. To avoid RequestLimitExceeded errors from AWS,
+    // Cluster Bootstrap already has its own retry/back-off mechanism. To avoid RequestLimitExceeded
+    // errors from AWS,
     // disable retries in the EC2 client configuration.
   }
-
 }
-//#custom-client-config
+// #custom-client-config

--- a/discovery-kubernetes-api/src/test/java/docs/KubernetesApiDiscoveryDocsTest.java
+++ b/discovery-kubernetes-api/src/test/java/docs/KubernetesApiDiscoveryDocsTest.java
@@ -20,8 +20,8 @@ import org.apache.pekko.discovery.ServiceDiscovery;
 public class KubernetesApiDiscoveryDocsTest {
   public void loadKubernetesApiDiscovery() {
     ActorSystem system = ActorSystem.create();
-    //#kubernetes-api-discovery
+    // #kubernetes-api-discovery
     ServiceDiscovery discovery = Discovery.get(system).loadServiceDiscovery("kubernetes-api");
-    //#kubernetes-api-discovery
+    // #kubernetes-api-discovery
   }
 }

--- a/integration-test/kubernetes-api-java/src/main/java/org/apache/pekko/cluster/bootstrap/demo/ClusterWatcher.java
+++ b/integration-test/kubernetes-api-java/src/main/java/org/apache/pekko/cluster/bootstrap/demo/ClusterWatcher.java
@@ -27,9 +27,10 @@ public class ClusterWatcher extends AbstractActor {
   @Override
   public Receive createReceive() {
     return ReceiveBuilder.create()
-      .matchAny(msg -> {
-        log.info("Cluster " + cluster.selfAddress() + " >>> " + msg);
-      })
-      .build();
+        .matchAny(
+            msg -> {
+              log.info("Cluster " + cluster.selfAddress() + " >>> " + msg);
+            })
+        .build();
   }
 }

--- a/integration-test/kubernetes-api-java/src/main/java/org/apache/pekko/cluster/bootstrap/demo/DemoApp.java
+++ b/integration-test/kubernetes-api-java/src/main/java/org/apache/pekko/cluster/bootstrap/demo/DemoApp.java
@@ -20,10 +20,10 @@ import org.apache.pekko.cluster.ClusterEvent;
 import org.apache.pekko.http.javadsl.ConnectHttp;
 import org.apache.pekko.http.javadsl.Http;
 import org.apache.pekko.http.javadsl.server.AllDirectives;
-//#start-pekko-management
+// #start-pekko-management
 import org.apache.pekko.management.javadsl.PekkoManagement;
 
-//#start-pekko-management
+// #start-pekko-management
 import org.apache.pekko.management.cluster.bootstrap.ClusterBootstrap;
 import org.apache.pekko.stream.Materializer;
 
@@ -35,25 +35,31 @@ public class DemoApp extends AllDirectives {
     Materializer mat = Materializer.createMaterializer(system);
     Cluster cluster = Cluster.get(system);
 
-    system.log().info("Started [" + system + "], cluster.selfAddress = " + cluster.selfAddress() + ")");
+    system
+        .log()
+        .info("Started [" + system + "], cluster.selfAddress = " + cluster.selfAddress() + ")");
 
-    //#start-pekko-management
+    // #start-pekko-management
     PekkoManagement.get(system).start();
-    //#start-pekko-management
+    // #start-pekko-management
     ClusterBootstrap.get(system).start();
 
-    cluster
-      .subscribe(system.actorOf(Props.create(ClusterWatcher.class)), ClusterEvent.initialStateAsEvents(), ClusterEvent.ClusterDomainEvent.class);
+    cluster.subscribe(
+        system.actorOf(Props.create(ClusterWatcher.class)),
+        ClusterEvent.initialStateAsEvents(),
+        ClusterEvent.ClusterDomainEvent.class);
 
-    Http.get(system).bindAndHandle(complete("Hello world").flow(system, mat), ConnectHttp.toHost("0.0.0.0", 8080), mat);
+    Http.get(system)
+        .bindAndHandle(
+            complete("Hello world").flow(system, mat), ConnectHttp.toHost("0.0.0.0", 8080), mat);
 
-    cluster.registerOnMemberUp(() -> {
-      system.log().info("Cluster member is up!");
-    });
+    cluster.registerOnMemberUp(
+        () -> {
+          system.log().info("Cluster member is up!");
+        });
   }
 
   public static void main(String[] args) {
     new DemoApp();
   }
 }
-

--- a/management-cluster-bootstrap/src/test/java/jdoc/org/apache/pekko/management/cluster/bootstrap/ClusterBootstrapCompileOnly.java
+++ b/management-cluster-bootstrap/src/test/java/jdoc/org/apache/pekko/management/cluster/bootstrap/ClusterBootstrapCompileOnly.java
@@ -18,16 +18,16 @@ import org.apache.pekko.management.scaladsl.PekkoManagement;
 import org.apache.pekko.management.cluster.bootstrap.ClusterBootstrap;
 
 public class ClusterBootstrapCompileOnly {
-    public static void bootstrap() {
+  public static void bootstrap() {
 
-        ActorSystem system = ActorSystem.create();
+    ActorSystem system = ActorSystem.create();
 
-        //#start
-        // Pekko Management hosts the HTTP routes used by bootstrap
-        PekkoManagement.get(system).start();
+    // #start
+    // Pekko Management hosts the HTTP routes used by bootstrap
+    PekkoManagement.get(system).start();
 
-        // Starting the bootstrap process needs to be done explicitly
-        ClusterBootstrap.get(system).start();
-        //#start
-    }
+    // Starting the bootstrap process needs to be done explicitly
+    ClusterBootstrap.get(system).start();
+    // #start
+  }
 }

--- a/management-cluster-bootstrap/src/test/java/org/apache/org/apache/pekko/management/cluster/bootstrap/ClusterBootstrapJavaCompileTest.java
+++ b/management-cluster-bootstrap/src/test/java/org/apache/org/apache/pekko/management/cluster/bootstrap/ClusterBootstrapJavaCompileTest.java
@@ -25,6 +25,5 @@ public class ClusterBootstrapJavaCompileTest {
   }
 
   @Test
-  public void compileOnly() {
-  }
+  public void compileOnly() {}
 }

--- a/management-cluster-http/src/main/java/org/apache/pekko/management/cluster/cluster/ClusterReadViewAccess.java
+++ b/management-cluster-http/src/main/java/org/apache/pekko/management/cluster/cluster/ClusterReadViewAccess.java
@@ -24,7 +24,8 @@ public class ClusterReadViewAccess {
   /**
    * INTERNAL API
    *
-   * Exposes the internal {@code readView} of the Akka Cluster, not reachable from Scala code because it is {@code private[cluster]}.
+   * <p>Exposes the internal {@code readView} of the Akka Cluster, not reachable from Scala code
+   * because it is {@code private[cluster]}.
    */
   @InternalApi
   public static ClusterReadView internalReadView(Cluster cluster) {

--- a/management-cluster-http/src/test/java/jdoc/org/apache/pekko/cluster/http/management/CompileOnlyTest.java
+++ b/management-cluster-http/src/test/java/jdoc/org/apache/pekko/cluster/http/management/CompileOnlyTest.java
@@ -16,26 +16,25 @@ package jdoc.org.apache.pekko.cluster.http.management;
 import org.apache.pekko.actor.ActorSystem;
 import org.apache.pekko.management.scaladsl.PekkoManagement;
 import org.apache.pekko.cluster.Cluster;
-//#imports
+// #imports
 import org.apache.pekko.http.javadsl.server.Route;
 import org.apache.pekko.management.cluster.javadsl.ClusterHttpManagementRoutes;
-//#imports
+// #imports
 
 public class CompileOnlyTest {
-    public static void example() {
-        //#loading
-        ActorSystem system = ActorSystem.create();
-        PekkoManagement.get(system).start();
-        //#loading
+  public static void example() {
+    // #loading
+    ActorSystem system = ActorSystem.create();
+    PekkoManagement.get(system).start();
+    // #loading
 
+    // #all
+    Cluster cluster = Cluster.get(system);
+    Route allRoutes = ClusterHttpManagementRoutes.all(cluster);
+    // #all
 
-        //#all
-        Cluster cluster = Cluster.get(system);
-        Route allRoutes = ClusterHttpManagementRoutes.all(cluster);
-        //#all
-
-        //#read-only
-        Route readOnlyRoutes = ClusterHttpManagementRoutes.readOnly(cluster);
-        //#read-only
-    }
+    // #read-only
+    Route readOnlyRoutes = ClusterHttpManagementRoutes.readOnly(cluster);
+    // #read-only
+  }
 }

--- a/management-cluster-http/src/test/java/org/apache/pekko/management/http/ClusterHttpManagementJavaCompileTest.java
+++ b/management-cluster-http/src/test/java/org/apache/pekko/management/http/ClusterHttpManagementJavaCompileTest.java
@@ -19,11 +19,11 @@ import org.junit.Test;
 
 public class ClusterHttpManagementJavaCompileTest {
 
-    public void test() {
-        ActorSystem actorSystem = ActorSystem.create("test");
-        ClusterHttpManagementRouteProvider x = ClusterHttpManagementRouteProvider.get(actorSystem);
-    }
+  public void test() {
+    ActorSystem actorSystem = ActorSystem.create("test");
+    ClusterHttpManagementRouteProvider x = ClusterHttpManagementRouteProvider.get(actorSystem);
+  }
 
-    @Test
-    public void compileOnly() {}
+  @Test
+  public void compileOnly() {}
 }

--- a/management-cluster-http/src/test/java/org/apache/pekko/management/http/javadsl/ClusterReadinessCheckTest.java
+++ b/management-cluster-http/src/test/java/org/apache/pekko/management/http/javadsl/ClusterReadinessCheckTest.java
@@ -18,14 +18,13 @@ import org.apache.pekko.management.cluster.javadsl.ClusterMembershipCheck;
 
 import java.util.concurrent.CompletionStage;
 
-
 public class ClusterReadinessCheckTest {
 
-   private static ActorSystem system = null;
+  private static ActorSystem system = null;
 
-   // test type works
-   public static CompletionStage<Boolean> worksFromJava() throws Exception {
-      ClusterMembershipCheck check = new ClusterMembershipCheck(system);
-      return check.get();
-   }
+  // test type works
+  public static CompletionStage<Boolean> worksFromJava() throws Exception {
+    ClusterMembershipCheck check = new ClusterMembershipCheck(system);
+    return check.get();
+  }
 }

--- a/management/src/test/java/jdoc/org/apache/pekko/management/BasicHealthCheck.java
+++ b/management/src/test/java/jdoc/org/apache/pekko/management/BasicHealthCheck.java
@@ -19,15 +19,14 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.function.Supplier;
 
-//#basic
+// #basic
 public class BasicHealthCheck implements Supplier<CompletionStage<Boolean>> {
 
-    public BasicHealthCheck(ActorSystem system) {
-    }
+  public BasicHealthCheck(ActorSystem system) {}
 
-    @Override
-    public CompletionStage<Boolean> get() {
-        return CompletableFuture.completedFuture(true);
-    }
+  @Override
+  public CompletionStage<Boolean> get() {
+    return CompletableFuture.completedFuture(true);
+  }
 }
-//#basic
+// #basic

--- a/management/src/test/java/jdoc/org/apache/pekko/management/ClusterCheck.java
+++ b/management/src/test/java/jdoc/org/apache/pekko/management/ClusterCheck.java
@@ -21,18 +21,18 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.function.Supplier;
 
-//#cluster
+// #cluster
 class ClusterCheck implements Supplier<CompletionStage<Boolean>> {
 
-    private final Cluster cluster;
+  private final Cluster cluster;
 
-    public ClusterCheck(ActorSystem system) {
-        cluster = Cluster.get(system);
-    }
+  public ClusterCheck(ActorSystem system) {
+    cluster = Cluster.get(system);
+  }
 
-    @Override
-    public CompletionStage<Boolean> get() {
-        return CompletableFuture.completedFuture(cluster.selfMember().status() == MemberStatus.up());
-    }
+  @Override
+  public CompletionStage<Boolean> get() {
+    return CompletableFuture.completedFuture(cluster.selfMember().status() == MemberStatus.up());
+  }
 }
-//#cluster
+// #cluster

--- a/management/src/test/java/org/apache/pekko/management/CodeExamples.java
+++ b/management/src/test/java/org/apache/pekko/management/CodeExamples.java
@@ -31,37 +31,39 @@ public class CodeExamples {
 
   public void start() {
     SSLContext sslContext = null;
-    //#start-pekko-management-with-https-context
+    // #start-pekko-management-with-https-context
     PekkoManagement management = PekkoManagement.get(system);
 
     HttpsConnectionContext https = ConnectionContext.https(sslContext);
     management.start(settings -> settings.withHttpsConnectionContext(https));
-    //#start-pekko-management-with-https-context
+    // #start-pekko-management-with-https-context
   }
 
   public void basicAuth() {
     PekkoManagement management = null;
 
-    //#basic-auth
-    final Function<Optional<SecurityDirectives.ProvidedCredentials>, CompletionStage<Optional<String>>>
-      myUserPassAuthenticator = opt -> {
-      if (opt.filter(c -> (c != null) && c.verify("p4ssw0rd")).isPresent()) {
-        return CompletableFuture.completedFuture(Optional.of(opt.get().identifier()));
-      } else {
-        return CompletableFuture.completedFuture(Optional.empty());
-      }
-    };
+    // #basic-auth
+    final Function<
+            Optional<SecurityDirectives.ProvidedCredentials>, CompletionStage<Optional<String>>>
+        myUserPassAuthenticator =
+            opt -> {
+              if (opt.filter(c -> (c != null) && c.verify("p4ssw0rd")).isPresent()) {
+                return CompletableFuture.completedFuture(Optional.of(opt.get().identifier()));
+              } else {
+                return CompletableFuture.completedFuture(Optional.empty());
+              }
+            };
     // ...
     management.start(settings -> settings.withAuth(myUserPassAuthenticator));
-    //#basic-auth
+    // #basic-auth
   }
 
   public void stop() {
-    //#stopping
+    // #stopping
     PekkoManagement httpClusterManagement = PekkoManagement.get(system);
     httpClusterManagement.start();
-    //...
+    // ...
     httpClusterManagement.stop();
-    //#stopping
+    // #stopping
   }
 }

--- a/management/src/test/java/org/apache/pekko/management/HealthCheckTest.java
+++ b/management/src/test/java/org/apache/pekko/management/HealthCheckTest.java
@@ -40,127 +40,127 @@ import java.util.function.Supplier;
 import static org.junit.Assert.assertEquals;
 
 public class HealthCheckTest extends JUnitSuite {
-    private static Throwable cause = new RuntimeException("oh dear");
+  private static Throwable cause = new RuntimeException("oh dear");
 
-
-    @SuppressWarnings("unused")
-    public static class Ok implements Supplier<CompletionStage<Boolean>> {
-        @Override
-        public CompletionStage<Boolean> get() {
-            return CompletableFuture.completedFuture(true);
-        }
+  @SuppressWarnings("unused")
+  public static class Ok implements Supplier<CompletionStage<Boolean>> {
+    @Override
+    public CompletionStage<Boolean> get() {
+      return CompletableFuture.completedFuture(true);
     }
+  }
 
-    @SuppressWarnings("unused")
-    public static class NotOk implements Supplier<CompletionStage<Boolean>> {
-        public NotOk(ActorSystem system) {
-        }
+  @SuppressWarnings("unused")
+  public static class NotOk implements Supplier<CompletionStage<Boolean>> {
+    public NotOk(ActorSystem system) {}
 
-        @Override
-        public CompletionStage<Boolean> get() {
-            return CompletableFuture.completedFuture(false);
-        }
+    @Override
+    public CompletionStage<Boolean> get() {
+      return CompletableFuture.completedFuture(false);
     }
+  }
 
-    @SuppressWarnings("unused")
-    public static class Throws implements Supplier<CompletionStage<Boolean>> {
-        public Throws(ActorSystem system) {
-        }
+  @SuppressWarnings("unused")
+  public static class Throws implements Supplier<CompletionStage<Boolean>> {
+    public Throws(ActorSystem system) {}
 
-        @Override
-        public CompletionStage<Boolean> get() {
-            return failed(cause);
-        }
+    @Override
+    public CompletionStage<Boolean> get() {
+      return failed(cause);
     }
+  }
 
-    private static ExtendedActorSystem system = (ExtendedActorSystem) ActorSystem.create();
+  private static ExtendedActorSystem system = (ExtendedActorSystem) ActorSystem.create();
 
-    @Test
-    public void okReturnsTrue() throws Exception {
-        List<NamedHealthCheck> healthChecks = Collections.singletonList(new NamedHealthCheck("Ok", "org.apache.pekko.management.HealthCheckTest$Ok"));
-        HealthChecks checks = new HealthChecks(system, HealthCheckSettings.create(
-                healthChecks,
-                healthChecks,
-                "ready",
-                "alive",
-                java.time.Duration.ofSeconds(1)
-        ));
-        assertEquals(true, checks.aliveResult().toCompletableFuture().get().isSuccess());
-        assertEquals(true, checks.readyResult().toCompletableFuture().get().isSuccess());
-        assertEquals(true, checks.alive().toCompletableFuture().get());
-        assertEquals(true, checks.ready().toCompletableFuture().get());
+  @Test
+  public void okReturnsTrue() throws Exception {
+    List<NamedHealthCheck> healthChecks =
+        Collections.singletonList(
+            new NamedHealthCheck("Ok", "org.apache.pekko.management.HealthCheckTest$Ok"));
+    HealthChecks checks =
+        new HealthChecks(
+            system,
+            HealthCheckSettings.create(
+                healthChecks, healthChecks, "ready", "alive", java.time.Duration.ofSeconds(1)));
+    assertEquals(true, checks.aliveResult().toCompletableFuture().get().isSuccess());
+    assertEquals(true, checks.readyResult().toCompletableFuture().get().isSuccess());
+    assertEquals(true, checks.alive().toCompletableFuture().get());
+    assertEquals(true, checks.ready().toCompletableFuture().get());
+  }
+
+  @Test
+  public void notOkayReturnsFalse() throws Exception {
+    List<NamedHealthCheck> healthChecks =
+        Collections.singletonList(
+            new NamedHealthCheck("Ok", "org.apache.pekko.management.HealthCheckTest$Ok"));
+    HealthChecks checks =
+        new HealthChecks(
+            system,
+            HealthCheckSettings.create(
+                healthChecks, healthChecks, "ready", "alive", java.time.Duration.ofSeconds(1)));
+    assertEquals(true, checks.aliveResult().toCompletableFuture().get().isSuccess());
+    assertEquals(true, checks.readyResult().toCompletableFuture().get().isSuccess());
+    assertEquals(true, checks.alive().toCompletableFuture().get());
+    assertEquals(true, checks.ready().toCompletableFuture().get());
+  }
+
+  @Test
+  public void throwsReturnsFailed() throws Exception {
+    List<NamedHealthCheck> healthChecks =
+        Collections.singletonList(
+            new NamedHealthCheck("Throws", "org.apache.pekko.management.HealthCheckTest$Throws"));
+    HealthChecks checks =
+        new HealthChecks(
+            system,
+            HealthCheckSettings.create(
+                healthChecks, healthChecks, "ready", "alive", java.time.Duration.ofSeconds(1)));
+    try {
+      checks.alive().toCompletableFuture().get();
+      Assert.fail("Expected exception");
+    } catch (ExecutionException re) {
+      assertEquals(cause, re.getCause().getCause());
     }
+  }
 
-    @Test
-    public void notOkayReturnsFalse() throws Exception {
-        List<NamedHealthCheck> healthChecks = Collections.singletonList(new NamedHealthCheck("Ok", "org.apache.pekko.management.HealthCheckTest$Ok"));
-        HealthChecks checks = new HealthChecks(system, HealthCheckSettings.create(
-                healthChecks,
-                healthChecks,
-                "ready",
-                "alive",
-                java.time.Duration.ofSeconds(1)
-        ));
-        assertEquals(true, checks.aliveResult().toCompletableFuture().get().isSuccess());
-        assertEquals(true, checks.readyResult().toCompletableFuture().get().isSuccess());
-        assertEquals(true, checks.alive().toCompletableFuture().get());
-        assertEquals(true, checks.ready().toCompletableFuture().get());
+  @Test
+  public void defineViaActorSystemSetup() throws Exception {
+    ReadinessCheckSetup readinessSetup =
+        ReadinessCheckSetup.create(system -> Arrays.asList(new Ok(), new NotOk(system)));
+    LivenessCheckSetup livenessSetup =
+        LivenessCheckSetup.create(system -> Collections.singletonList(new NotOk(system)));
+    // bootstrapSetup is needed for config (otherwise default config)
+    BootstrapSetup bootstrapSetup = BootstrapSetup.create(ConfigFactory.parseString("some=thing"));
+    ActorSystemSetup actorSystemSetup =
+        ActorSystemSetup.create(bootstrapSetup, readinessSetup, livenessSetup);
+    ExtendedActorSystem sys2 =
+        (ExtendedActorSystem) ActorSystem.create("HealthCheckTest2", actorSystemSetup);
+    try {
+      HealthChecks checks =
+          new HealthChecks(
+              sys2,
+              HealthCheckSettings.create(
+                  Collections.emptyList(),
+                  Collections.emptyList(),
+                  "ready",
+                  "alive",
+                  java.time.Duration.ofSeconds(1)));
+      assertEquals(false, checks.aliveResult().toCompletableFuture().get().isSuccess());
+      assertEquals(false, checks.readyResult().toCompletableFuture().get().isSuccess());
+      assertEquals(false, checks.alive().toCompletableFuture().get());
+      assertEquals(false, checks.ready().toCompletableFuture().get());
+    } finally {
+      TestKit.shutdownActorSystem(sys2);
     }
+  }
 
-    @Test
-    public void throwsReturnsFailed() throws Exception {
-        List<NamedHealthCheck> healthChecks = Collections.singletonList(
-                new NamedHealthCheck("Throws", "org.apache.pekko.management.HealthCheckTest$Throws"));
-        HealthChecks checks = new HealthChecks(system, HealthCheckSettings.create(
-                healthChecks,
-                healthChecks,
-                "ready",
-                "alive",
-                java.time.Duration.ofSeconds(1)
-        ));
-        try {
-            checks.alive().toCompletableFuture().get();
-            Assert.fail("Expected exception");
-        } catch (ExecutionException re) {
-            assertEquals(cause, re.getCause().getCause());
-        }
-    }
+  @AfterClass
+  public static void cleanup() {
+    TestKit.shutdownActorSystem(system);
+  }
 
-    @Test
-    public void defineViaActorSystemSetup() throws Exception {
-        ReadinessCheckSetup readinessSetup =
-          ReadinessCheckSetup.create(system -> Arrays.asList(new Ok(), new NotOk(system)));
-        LivenessCheckSetup livenessSetup =
-          LivenessCheckSetup.create(system -> Collections.singletonList(new NotOk(system)));
-        // bootstrapSetup is needed for config (otherwise default config)
-        BootstrapSetup bootstrapSetup = BootstrapSetup.create(ConfigFactory.parseString("some=thing"));
-        ActorSystemSetup actorSystemSetup = ActorSystemSetup.create(bootstrapSetup, readinessSetup, livenessSetup);
-        ExtendedActorSystem sys2 = (ExtendedActorSystem) ActorSystem.create("HealthCheckTest2", actorSystemSetup);
-        try {
-            HealthChecks checks = new HealthChecks(sys2, HealthCheckSettings.create(
-              Collections.emptyList(),
-              Collections.emptyList(),
-              "ready",
-              "alive",
-              java.time.Duration.ofSeconds(1)
-            ));
-            assertEquals(false, checks.aliveResult().toCompletableFuture().get().isSuccess());
-            assertEquals(false, checks.readyResult().toCompletableFuture().get().isSuccess());
-            assertEquals(false, checks.alive().toCompletableFuture().get());
-            assertEquals(false, checks.ready().toCompletableFuture().get());
-      } finally {
-        TestKit.shutdownActorSystem(sys2);
-      }
-    }
-
-    @AfterClass
-    public static void cleanup() {
-        TestKit.shutdownActorSystem(system);
-    }
-
-    private static <R> CompletableFuture<R> failed(Throwable error) {
-        CompletableFuture<R> future = new CompletableFuture<>();
-        future.completeExceptionally(error);
-        return future;
-    }
+  private static <R> CompletableFuture<R> failed(Throwable error) {
+    CompletableFuture<R> future = new CompletableFuture<>();
+    future.completeExceptionally(error);
+    return future;
+  }
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,6 +2,7 @@ addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.9.9")
 
 addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.9.0")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.6")
+addSbtPlugin("com.lightbend.sbt" % "sbt-java-formatter" % "0.7.0")
 addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.1.1")
 addSbtPlugin("com.github.sbt" % "sbt-unidoc" % "0.5.0")
 addSbtPlugin("com.typesafe.sbt" % "sbt-site" % "1.4.1")


### PR DESCRIPTION
It seems like this project historically has not integrated javafmt, so this PR formats the codebase with javafmt as well as updating the `verifyCodeFmt` to use sbt-javafmt.

Note, please do not do a squash and merge when merging this PR. Since a format commit is being added I need to add its hash (and only its hash) to `.git-blame-ignore-revs` (to be safe just let me merge the PR).