### PR TITLE
Add javafmt format commit to .git-blame-ignore-revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,2 +1,5 @@
 # scalafmt
 7ce76e2584fc2e23f35a121e55a55aaf33852749
+
+# javafmt
+ad4f657da9481d9685a0fec187a929fad89a4d07


### PR DESCRIPTION
So it doesn't appear in git blame