### PR TITLE
Fix javadoc issue

### DIFF
--- a/project/Common.scala
+++ b/project/Common.scala
@@ -47,6 +47,8 @@ object Common extends AutoPlugin {
       },
       javacOptions ++= Seq(
         "-Xlint:unchecked"),
+      // Necessary otherwise javadoc fails with Unexpected javac output: javadoc: error - invalid flag: -Xlint:unchecked.
+      Compile / doc / javacOptions -= "-Xlint:unchecked",
       javacOptions ++= (
         if (isJdk8) Seq.empty
         else Seq("--release", "8")


### PR DESCRIPTION
Latest SBT seems to have stricter checking for javadoc where it fails if invalid flags are passed, this fixes the problem https://github.com/apache/incubator-pekko-management/actions/runs/4921013699/jobs/8790417321, if you describe the error locally it shows the problem

```
[warn] Unexpected javac output: javadoc: error - invalid flag: -Xlint:unchecked.
[info] Usage: javadoc [options] [packagenames] [sourcefiles] [@files]
[info]   -overview <file>                 Read overview documentation from HTML file
[info]   -public                          Show only public classes and members
[info]   -protected                       Show protected/public classes and members (default)
[info]   -package                         Show package/protected/public classes and members
[info]   -private                         Show all classes and members
[info]   -help                            Display command line options and exit
[info]   -doclet <class>                  Generate output via alternate doclet
[info]   -docletpath <path>               Specify where to find doclet class files
[info]   -sourcepath <pathlist>           Specify where to find source files
[info]   -classpath <pathlist>            Specify where to find user class files
[info]   -cp <pathlist>                   Specify where to find user class files
[info]   -exclude <pkglist>               Specify a list of packages to exclude
[info]   -subpackages <subpkglist>        Specify subpackages to recursively load
[info]   -breakiterator                   Compute first sentence with BreakIterator
[info]   -bootclasspath <pathlist>        Override location of class files loaded
[info]                                    by the bootstrap class loader
[info]   -source <release>                Provide source compatibility with specified release
[info]   -extdirs <dirlist>               Override location of installed extensions
[info]   -verbose                         Output messages about what Javadoc is doing
[info]   -locale <name>                   Locale to be used, e.g. en_US or en_US_WIN
[info]   -encoding <name>                 Source file encoding name
[info]   -quiet                           Do not display status messages
[info]   -J<flag>                         Pass <flag> directly to the runtime system
[info]   -X                               Print a synopsis of nonstandard options and exit
[info] 1 error
[warn] javadoc exited with exit code 1
[error] stack trace is suppressed; run last integration-test-kubernetes-api-java / Compile / doc for the full output
[error] (integration-test-kubernetes-api-java / Compile / doc) sbt.inc.Doc$JavadocGenerationFailed
[error] Total time: 9 s, completed May 9, 2023 9:47:15 PM
```