### PR TITLE
Unwrap single string interpolation syntax

### DIFF
--- a/discovery-consul/src/main/scala/org/apache/pekko/discovery/consul/ConsulServiceDiscovery.scala
+++ b/discovery-consul/src/main/scala/org/apache/pekko/discovery/consul/ConsulServiceDiscovery.scala
@@ -48,7 +48,7 @@ class ConsulServiceDiscovery(system: ActorSystem) extends ServiceDiscovery {
     Future.firstCompletedOf(
       Seq(
         after(resolveTimeout, using = system.scheduler)(
-          Future.failed(new TimeoutException(s"Lookup for [${lookup}] timed-out, within [${resolveTimeout}]!"))),
+          Future.failed(new TimeoutException(s"Lookup for [$lookup] timed-out, within [$resolveTimeout]!"))),
         lookupInConsul(lookup.serviceName)))
   }
 

--- a/lease-kubernetes/src/main/scala/org/apache/pekko/coordination/lease/kubernetes/internal/KubernetesApiImpl.scala
+++ b/lease-kubernetes/src/main/scala/org/apache/pekko/coordination/lease/kubernetes/internal/KubernetesApiImpl.scala
@@ -170,7 +170,7 @@ PUTs must contain resourceVersions. Response:
           getLeaseResource(leaseName).flatMap {
             case None =>
               Future.failed(
-                new LeaseException(s"GET after PUT conflict did not return a lease. Lease[${leaseName}-${ownerName}]"))
+                new LeaseException(s"GET after PUT conflict did not return a lease. Lease[$leaseName-$ownerName]"))
             case Some(lr) =>
               log.debug("LeaseResource read after conflict: {}", lr)
               Future.successful(Left(lr))
@@ -183,7 +183,7 @@ PUTs must contain resourceVersions. Response:
             .flatMap(body => {
               Future.failed(
                 new LeaseException(
-                  s"PUT for lease $leaseName returned unexpected status code ${unexpected}. Body: ${body}"))
+                  s"PUT for lease $leaseName returned unexpected status code $unexpected. Body: $body"))
             })
       }
     } yield result
@@ -218,7 +218,7 @@ PUTs must contain resourceVersions. Response:
   }
 
   private def getLeaseResource(name: String): Future[Option[LeaseResource]] = {
-    val fResponse = makeRequest(requestForPath(pathForLease(name)), s"Timed out reading lease ${name}")
+    val fResponse = makeRequest(requestForPath(pathForLease(name)), s"Timed out reading lease $name")
     for {
       response <- fResponse
       entity <- response.entity.toStrict(settings.bodyReadTimeout)
@@ -242,7 +242,7 @@ PUTs must contain resourceVersions. Response:
             .to[String]
             .flatMap(body => {
               Future.failed(new LeaseException(
-                s"Unexpected response from API server when retrieving lease StatusCode: ${unexpected}. Body: ${body}"))
+                s"Unexpected response from API server when retrieving lease StatusCode: $unexpected. Body: $body"))
             })
       }
     } yield lr
@@ -253,7 +253,7 @@ PUTs must contain resourceVersions. Response:
       .to[String]
       .flatMap(body => {
         Future.failed(new LeaseException(
-          s"Unauthorized to communicate with Kubernetes API server. See https://pekko.apache.org/docs/pekko-management/current/kubernetes-lease.html#role-based-access-control for setting up access control. Body: ${body}"))
+          s"Unauthorized to communicate with Kubernetes API server. See https://pekko.apache.org/docs/pekko-management/current/kubernetes-lease.html#role-based-access-control for setting up access control. Body: $body"))
       })
   }
 
@@ -324,7 +324,7 @@ PUTs must contain resourceVersions. Response:
             .flatMap(body => {
               Future.failed(
                 new LeaseException(
-                  s"Unexpected response from API server when creating Lease StatusCode: ${unexpected}. Body: ${body}"))
+                  s"Unexpected response from API server when creating Lease StatusCode: $unexpected. Body: $body"))
             })
       }
     } yield lr

--- a/management-cluster-bootstrap/src/test/scala/org/apache/pekko/management/cluster/bootstrap/contactpoint/ClusterBootstrapDiscoveryBackoffIntegrationSpec.scala
+++ b/management-cluster-bootstrap/src/test/scala/org/apache/pekko/management/cluster/bootstrap/contactpoint/ClusterBootstrapDiscoveryBackoffIntegrationSpec.scala
@@ -194,7 +194,7 @@ class ClusterBootstrapDiscoveryBackoffIntegrationSpec
           override def accept(system: ActorSystem, stats: SystemStats): Unit = {
             stats.called shouldBe >=(5)
             val durationBetweenCall2And3 = (stats.call3Timestamp - stats.call2Timestamp).nanos.toMillis
-            info(s"${Cluster(system).selfAddress}: duration between call 2 and 3 ${durationBetweenCall2And3} ms")
+            info(s"${Cluster(system).selfAddress}: duration between call 2 and 3 $durationBetweenCall2And3 ms")
             durationBetweenCall2And3 shouldBe >=(
               (ClusterBootstrap(system).settings.contactPointDiscovery.interval * 2).toMillis)
           }

--- a/management-cluster-bootstrap/src/test/scala/org/apache/pekko/management/cluster/bootstrap/contactpoint/ClusterBootstrapExistingSeedNodesSpec.scala
+++ b/management-cluster-bootstrap/src/test/scala/org/apache/pekko/management/cluster/bootstrap/contactpoint/ClusterBootstrapExistingSeedNodesSpec.scala
@@ -60,7 +60,7 @@ class ClusterBootstrapExistingSeedNodesSpec(system: ActorSystem)
       else "pekko.tcp"
 
     val seeds = (seedNodes match {
-      case JoinYourself => List(s"${protocol}://${systemName}@127.0.0.1:${remotingPort}")
+      case JoinYourself => List(s"$protocol://$systemName@127.0.0.1:$remotingPort")
       case _            => seedNodes.map(_.toString)
     }).mkString("""["""", """", """", """"] """)
 
@@ -70,7 +70,7 @@ class ClusterBootstrapExistingSeedNodesSpec(system: ActorSystem)
 
           cluster.jmx.multi-mbeans-in-same-jvm = on
 
-          cluster.seed-nodes = ${seeds}
+          cluster.seed-nodes = $seeds
 
           cluster.http.management.port = $managementPort
           remote.netty.tcp.port = $remotingPort

--- a/management/src/main/scala/org/apache/pekko/management/PekkoManagementSettings.scala
+++ b/management/src/main/scala/org/apache/pekko/management/PekkoManagementSettings.scala
@@ -38,7 +38,7 @@ final class PekkoManagementSettings(val config: Config) {
 
     val Port: Int = {
       val p = cc.getInt("port")
-      require(0 to 65535 contains p, s"pekko.management.http.port must be 0 through 65535 (was ${p})")
+      require(0 to 65535 contains p, s"pekko.management.http.port must be 0 through 65535 (was $p)")
       p
     }
 
@@ -51,7 +51,7 @@ final class PekkoManagementSettings(val config: Config) {
       case "" => Port
       case value =>
         val p = value.toInt
-        require(0 to 65535 contains p, s"pekko.management.http.bind-port must be 0 through 65535 (was ${p})")
+        require(0 to 65535 contains p, s"pekko.management.http.bind-port must be 0 through 65535 (was $p)")
         p
     }
 

--- a/management/src/test/scala/org/apache/pekko/management/HealthCheckRoutesSpec.scala
+++ b/management/src/test/scala/org/apache/pekko/management/HealthCheckRoutesSpec.scala
@@ -45,7 +45,7 @@ class HealthCheckRoutesSpec extends AnyWordSpec with Matchers with ScalatestRout
   tests("/alive", result => testRoute(aliveResultValue = result))
 
   def tests(endpoint: String, route: Future[Either[String, Unit]] => Route) = {
-    s"Health check ${endpoint} endpoint" should {
+    s"Health check $endpoint endpoint" should {
       "return 200 for Right" in {
         Get(endpoint) ~> route(Future.successful(Right(()))) ~> check {
           status shouldEqual StatusCodes.OK

--- a/project/CopyrightHeader.scala
+++ b/project/CopyrightHeader.scala
@@ -67,7 +67,7 @@ trait CopyrightHeader extends AutoPlugin {
         case Some(currentText) if isOnlyLightbendCopyrightAnnotated(currentText) =>
           HeaderCommentStyle.cStyleBlockComment.commentCreator(text, existingText) + NewLine * 2 + currentText
         case Some(currentText) =>
-          throw new IllegalStateException(s"Unable to detect copyright for header:[${currentText}]")
+          throw new IllegalStateException(s"Unable to detect copyright for header:[$currentText]")
         case None =>
           HeaderCommentStyle.cStyleBlockComment.commentCreator(text, existingText)
       }


### PR DESCRIPTION
Unwraps single string interpolation i.e. `s"${something}"` into `s"$something"`. Make sure to do a rebase merge of this PR because I need to add its commit to `.git-blame-ignore-revs`