### PR TITLE
Add unwrap single string into .git-ignore-blame-revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -3,3 +3,6 @@
 
 # javafmt
 ad4f657da9481d9685a0fec187a929fad89a4d07
+
+# manual
+8fe6f50bb1541cf0551d094f9c7906d2a6ca6bf5


### PR DESCRIPTION
Adds the changes from https://github.com/apache/incubator-pekko-management/pull/82 into `.git-ignore-blame-revs`.