### PR TITLE
Cache snapshots to prevent overloading Apache Nexus repo

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,9 @@ ThisBuild / versionScheme := Some(VersionScheme.SemVerSpec)
 sourceDistName := "incubating-pekko-management"
 
 ThisBuild / resolvers += Resolver.jcenterRepo
+// TODO: Remove when Pekko has a proper release
 ThisBuild / resolvers += Resolver.ApacheMavenSnapshotsRepo
+ThisBuild / updateOptions := updateOptions.value.withLatestSnapshots(false)
 
 // root
 lazy val root = project

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -16,6 +16,7 @@ addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "1.1.0")
 resolvers += Resolver.jcenterRepo
 // allow access to snapshots for pekko-sbt-paradox
 resolvers += Resolver.ApacheMavenSnapshotsRepo
+updateOptions := updateOptions.value.withLatestSnapshots(false)
 
 // We have to deliberately use older versions of sbt-paradox because current Pekko sbt build
 // only loads on JDK 1.8 so we need to bring in older versions of parboiled which support JDK 1.8


### PR DESCRIPTION
The Apache Snapshots nexus repo is sometimes giving us request refused, likely because we are overloading the repo with excessive amount of requests.  This is due to the fact that we are using `SNAPSHOT` versions which by default don't cache because they are mutable (i.e. you can reupload snapshots with different implementations as much as you like).

Since for both pekko and its project forks the snapshot version is derived from git hash, there is no disadvantage to caching the snapshot.