### PR TITLE
downgrade pekko snapshots

### DIFF
--- a/integration-test/kubernetes-api-java/pom.xml
+++ b/integration-test/kubernetes-api-java/pom.xml
@@ -18,8 +18,8 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <encoding>UTF-8</encoding>
-    <pekko.version>0.0.0+26656-898c6970-SNAPSHOT</pekko.version>
-    <pekko.http.version>0.0.0+4345-fa1cb9cb-SNAPSHOT</pekko.http.version>
+    <pekko.version>0.0.0+26669-ec5b6764-SNAPSHOT</pekko.version>
+    <pekko.http.version>0.0.0+4411-6fe04045-SNAPSHOT</pekko.http.version>
     <pekko-management.version>0.0.0</pekko-management.version> <!-- set by build -->
     <scala.binary.version>2.13</scala.binary.version>
   </properties>

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -18,8 +18,8 @@ object Dependencies {
   val crossScalaVersions = Seq(scala212Version, scala213Version, scala3Version)
 
   // Align the versions in integration-test/kubernetes-api-java/pom.xml
-  val pekkoVersion = "0.0.0+26720-01379c41-SNAPSHOT"
-  val pekkoHttpVersion = "0.0.0+4431-0dc1da23-SNAPSHOT"
+  val pekkoVersion = "0.0.0+26669-ec5b6764-SNAPSHOT"
+  val pekkoHttpVersion = "0.0.0+4411-6fe04045-SNAPSHOT"
 
   val scalaTestVersion = "3.2.14"
   val scalaTestPlusJUnitVersion = scalaTestVersion + ".0"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -29,7 +29,7 @@ updateOptions := updateOptions.value.withLatestSnapshots(false)
 
 // We have to deliberately use older versions of sbt-paradox because current Pekko sbt build
 // only loads on JDK 1.8 so we need to bring in older versions of parboiled which support JDK 1.8
-addSbtPlugin(("org.apache.pekko" % "pekko-sbt-paradox" % "0.0.0+37-3df33944-SNAPSHOT").excludeAll(
+addSbtPlugin(("org.apache.pekko" % "pekko-sbt-paradox" % "0.0.0+38-68da3106-SNAPSHOT").excludeAll(
   "com.lightbend.paradox", "sbt-paradox",
   "com.lightbend.paradox" % "sbt-paradox-apidoc",
   "com.lightbend.paradox" % "sbt-paradox-project-info"))


### PR DESCRIPTION
the versions are too new and don't play well with the versions used in other modules

https://cwiki.apache.org/confluence/display/PEKKO/Testing+with+Pekko+Snapshot+Jars

https://github.com/apache/incubator-pekko-samples/actions/runs/5357290384