### PR TITLE
Remove references to lagom in docs

### DIFF
--- a/docs/src/main/paradox/kubernetes-lease.md
+++ b/docs/src/main/paradox/kubernetes-lease.md
@@ -24,8 +24,8 @@ and its backing `etcd` cluster can also be subject to failure and network issues
 ### Lease Instances
 
 * With @extref[Split Brain Resolver](pekko:split-brain-resolver.html#lease) there will be one lease per Pekko Cluster
-* With multiple Pekko Clusters using SBRs in the same namespace, e.g. multiple Lagom 
-applications, you must ensure different `ActorSystem` names because they all need a separate lease. 
+* With multiple Pekko Clusters using SBRs in the same namespace you must ensure
+different `ActorSystem` names because they all need a separate lease. 
 * With Cluster Sharding and Cluster Singleton there will be more leases 
     - For @extref:[Cluster Singleton](pekko:typed/cluster-singleton.html#lease) there will be one per singleton.
     - For @extref:[Cluster Sharding](pekko:typed/cluster-sharding.html#lease), there will be one per shard per type.

--- a/docs/src/main/paradox/pekko-management.md
+++ b/docs/src/main/paradox/pekko-management.md
@@ -53,8 +53,6 @@ This allows users to prepare anything further before exposing routes for
 the bootstrap joining process and other purposes.
 
 Remember to call `stop` method preferably in @extref:[Coordinated Shutdown](pekko:coordinated-shutdown.html).
-See [the Lagom example](https://github.com/lagom/lagom/blob/50ecfbf2e0d51fe24fdf6ad71157e1dff97106b9/akka-management/core/src/main/scala/com/lightbend/lagom/internal/akka/management/AkkaManagementTrigger.scala#L73).
-
 
 ## Basic Configuration
 


### PR DESCRIPTION
I came across these references by accident. Considering that Lagom is both a dead project and is tied to Akka (I seriously doubt they want to have anything to do with Pekko) don't think its appropriate to reference them in the docs.

Its a bit of a shame that we are losing some example code, but if someone can suggest replacements than that would be fantastic