### PR TITLE
test with newer versions of log4j and logback

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -25,8 +25,8 @@ object Dependencies {
   val awsSdkVersion = "1.12.210"
   val jacksonVersion = "2.14.3"
 
-  val log4j2Version = "2.17.2"
-  val logbackVersion = "1.2.11"
+  val log4j2Version = "2.21.1"
+  val logbackVersion = "1.3.11"
 
   // often called-in transitively with insecure versions of databind / core
   private val jacksonDatabind = Seq(


### PR DESCRIPTION
* see #132 
* the broken tests are only run in the nightly build but I've tested on my laptop to prove they pass after this change