### PR TITLE
protect 1.0.x branch

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -45,6 +45,18 @@ github:
         dismiss_stale_reviews: false
         require_code_owner_reviews: false
         required_approving_review_count: 1
+    1.0.x:
+      required_status_checks:
+        # strict means "Require branches to be up to date before merging".
+        strict: false
+        # contexts are the names of checks that must pass
+        contexts:
+          - Code is formatted
+          - Check headers
+      required_pull_request_reviews:
+        dismiss_stale_reviews: false
+        require_code_owner_reviews: false
+        required_approving_review_count: 1        
 
 notifications:
   commits:              commits@pekko.apache.org


### PR DESCRIPTION
need to have 1.0.x branch because pekko-management tests no longer pass with pekko 1.1 snapshots due to slf4j upgrade in pekko 1.1