### PR TITLE
use slf4j2 compatible jars when testing with pekko 1.1

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -23,10 +23,13 @@ object Dependencies {
   val scalaTestPlusJUnitVersion = scalaTestVersion + ".0"
 
   val awsSdkVersion = "1.12.210"
+  val awsSdk2Version = "2.17.184"
   val jacksonVersion = "2.14.3"
 
-  val log4j2Version = "2.17.2"
-  val logbackVersion = "1.2.11"
+  val (log4jSlf4jBridgeJar, log4j2Version, logbackVersion) = if (pekkoVersion.startsWith("1.0"))
+    ("log4j-slf4j-impl", "2.17.2", "1.2.11")
+  else
+    ("log4j-slf4j2-impl", "2.21.1", "1.3.11")
 
   // often called-in transitively with insecure versions of databind / core
   private val jacksonDatabind = Seq(
@@ -77,7 +80,7 @@ object Dependencies {
     "org.apache.pekko" %% "pekko-stream" % pekkoVersion,
     "org.apache.pekko" %% "pekko-http" % pekkoHttpVersion,
     "org.apache.pekko" %% "pekko-http-spray-json" % pekkoHttpVersion,
-    ("software.amazon.awssdk" % "ecs" % "2.17.184").exclude("software.amazon.awssdk", "apache-client"),
+    ("software.amazon.awssdk" % "ecs" % awsSdk2Version).exclude("software.amazon.awssdk", "apache-client"),
     "org.scalatest" %% "scalatest" % scalaTestVersion % Test) ++ jacksonDatabind // aws-java-sdk depends on insecure version of jackson
 
   val managementHttp = Seq(
@@ -113,7 +116,7 @@ object Dependencies {
     "org.apache.pekko" %% "pekko-stream" % pekkoVersion,
     "org.apache.logging.log4j" % "log4j-core" % log4j2Version,
     "org.apache.logging.log4j" % "log4j-api" % log4j2Version,
-    "org.apache.logging.log4j" % "log4j-slf4j-impl" % log4j2Version,
+    "org.apache.logging.log4j" % log4jSlf4jBridgeJar % log4j2Version,
     "org.apache.pekko" %% "pekko-http" % pekkoHttpVersion,
     "org.apache.pekko" %% "pekko-http-spray-json" % pekkoHttpVersion,
     "org.scalatest" %% "scalatest" % scalaTestVersion % Test,


### PR DESCRIPTION
replacement for https://github.com/apache/incubator-pekko-management/pull/133 - see also #132

slf4j v1 and slf4j v2 are not fully compatible - when slf4j-api v1 dependency exists, you can't use slf4j v2 implementations and likewise, you can't mix slf4j-api v2 with slf4j v1 implementations.

If this is merged - I can follow up with a doc change to highlight what slf4j v2 users need to do in their deployments.