### PR TITLE
fix nightly build tests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -32,36 +32,50 @@ inThisBuild(Def.settings(
     (Global / onLoad).value
   }))
 
+val logLevelProjectList: Seq[ProjectReference] = {
+  if (System.getProperty(PekkoDependency.pekkoBuildVersionPropertyName) == "main") {
+    Seq.empty
+  } else {
+    Seq[ProjectReference](managementLoglevelsLogback)
+  }
+} ++ {
+  if (System.getProperty(PekkoDependency.pekkoBuildVersionPropertyName) == "main"
+    && !Common.testWithSlf4J2) {
+    Seq.empty
+  } else {
+    Seq[ProjectReference](managementLoglevelsLogback)
+  }
+} ++ Seq[ProjectReference](managementLoglevelsLog4j2Slf4j2)
+
+val projectList: Seq[ProjectReference] = Seq[ProjectReference](
+  // When this aggregate is updated the list of modules in ManifestInfo.checkSameVersion
+  // in management should also be updated
+  discoveryAwsApi,
+  discoveryAwsApiAsync,
+  discoveryConsul,
+  discoveryKubernetesApi,
+  discoveryMarathonApi,
+  management,
+  managementPki,
+  managementClusterHttp,
+  managementClusterBootstrap) ++ logLevelProjectList ++ Seq[ProjectReference](
+  integrationTestAwsApiEc2TagBased,
+  integrationTestLocal,
+  integrationTestAwsApiEcs,
+  integrationTestKubernetesApi,
+  integrationTestKubernetesApiJava,
+  integrationTestKubernetesDns,
+  integrationTestMarathonApiDocker,
+  leaseKubernetes,
+  leaseKubernetesIntTest,
+  docs)
+
 // root
 lazy val root = project
   .in(file("."))
   .enablePlugins(ScalaUnidocPlugin)
   .disablePlugins(MimaPlugin)
-  .aggregate(
-    // When this aggregate is updated the list of modules in ManifestInfo.checkSameVersion
-    // in management should also be updated
-    discoveryAwsApi,
-    discoveryAwsApiAsync,
-    discoveryConsul,
-    discoveryKubernetesApi,
-    discoveryMarathonApi,
-    management,
-    managementPki,
-    managementClusterHttp,
-    managementClusterBootstrap,
-    managementLoglevelsLogback,
-    managementLoglevelsLog4j2,
-    managementLoglevelsLog4j2Slf4j2,
-    integrationTestAwsApiEc2TagBased,
-    integrationTestLocal,
-    integrationTestAwsApiEcs,
-    integrationTestKubernetesApi,
-    integrationTestKubernetesApiJava,
-    integrationTestKubernetesDns,
-    integrationTestMarathonApiDocker,
-    leaseKubernetes,
-    leaseKubernetesIntTest,
-    docs)
+  .aggregate(projectList: _*)
   .settings(
     name := "pekko-management-root",
     GlobalScope / parallelExecution := false)

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -96,6 +96,8 @@ object Common extends AutoPlugin {
   override lazy val buildSettings = Seq(
     dynverSonatypeSnapshots := true)
 
+  val testWithSlf4J2: Boolean = java.lang.Boolean.getBoolean("pekko.test.slf4j2")
+
   private def isJdk8 =
     VersionNumber(sys.props("java.specification.version")).matchesSemVer(SemanticSelector(s"=1.8"))
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -110,7 +110,7 @@ object Dependencies {
     "org.apache.pekko" %% "pekko-testkit" % pekkoVersion % Test,
     "org.apache.pekko" %% "pekko-http-testkit" % pekkoHttpVersion % Test)
 
-  val managementLoglevelsLogbackSlf4j2Overrides = if (java.lang.Boolean.getBoolean("pekko.test.slf4j2")) {
+  val managementLoglevelsLogbackSlf4j2Overrides = if (Common.testWithSlf4J2) {
     Seq(
       "org.slf4j" % "slf4j-api" % "2.0.9",
       "ch.qos.logback" % "logback-classic" % "1.3.11" % Test)

--- a/project/PekkoDependency.scala
+++ b/project/PekkoDependency.scala
@@ -18,6 +18,8 @@ import scala.util.matching.Regex.Groups
 
 object PekkoDependency {
 
+  val pekkoBuildVersionPropertyName = "pekko.build.pekko.version"
+
   sealed trait Pekko {
     def version: String
     // The version to use in api/japi/docs links,
@@ -36,7 +38,7 @@ object PekkoDependency {
       case Some(pekkoSources) =>
         Sources(pekkoSources)
       case None =>
-        Option(System.getProperty("pekko.build.pekko.version")) match {
+        Option(System.getProperty(pekkoBuildVersionPropertyName)) match {
           case Some("main")           => mainSnapshot
           case Some("default") | None => Artifact(defaultVersion)
           case Some(other)            => Artifact(other, true)


### PR DESCRIPTION
* 'main' pekko is v1.1.0-SNAPSHOT and it includes slf4j v2
* when building with 'main' - we need to skip the loglevel tests that are sensitive to the slf4j version
* we will not publish with 'main' - so this only affects what tests we run 