### PR TITLE
upgrade logback and log4j

### DIFF
--- a/integration-test/kubernetes-api-java/pom.xml
+++ b/integration-test/kubernetes-api-java/pom.xml
@@ -43,7 +43,7 @@
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
-      <version>1.2.12</version>
+      <version>1.2.13</version>
     </dependency>
     <dependency>
       <groupId>org.apache.pekko</groupId>

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -26,9 +26,9 @@ object Dependencies {
   val jacksonVersion = "2.14.3"
 
   val log4j2Version = "2.17.2"
-  val log4j2Slf4j2Version = "2.21.1"
-  val logbackVersion = "1.2.11"
-  val logbackSlf4j2Version = "1.3.13"
+  val log4j2Slf4j2Version = "2.22.0"
+  val logbackVersion = "1.2.13"
+  val logbackSlf4j2Version = "1.3.14"
   val slf4j2Version = "2.0.9"
 
   // often called-in transitively with insecure versions of databind / core
@@ -113,7 +113,7 @@ object Dependencies {
   val managementLoglevelsLogbackSlf4j2Overrides = if (Common.testWithSlf4J2) {
     Seq(
       "org.slf4j" % "slf4j-api" % "2.0.9",
-      "ch.qos.logback" % "logback-classic" % "1.3.13" % Test)
+      "ch.qos.logback" % "logback-classic" % "1.3.14" % Test)
   } else {
     Seq.empty
   }


### PR DESCRIPTION
lots of fixes for https://github.com/advisories/GHSA-vmq6-5m68-f53m going in

the new slf4jv2 support for log4j is not yet released so it is also safe to update log4j that is used in that unreleased component